### PR TITLE
Inline directly the default transparentImage

### DIFF
--- a/cloud-zoom.js
+++ b/cloud-zoom.js
@@ -393,7 +393,7 @@
         zoomWidth: 'auto',
         zoomHeight: 'auto',
         position: 'right',
-        transparentImage: '.',
+        transparentImage: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
         useWrapper: true,
         tint: false,
         tintOpacity: 0.5,


### PR DESCRIPTION
Great work. Maybe you consider this useful.

The default option "." results in a ajax request that most probably is a  404 page or HTML page. 

Provide a useful and not broken experience by default. Specially for users who are using this library as drop-in-replacement, since then "transparentImage" was not part of the original library.

In our case, we use the library through https://www.drupal.org/project/cloud_zoom, so we can't access the original plugin js initialisation options.

Thanks
